### PR TITLE
Moving mIgnoreIteration to the top of the afterTextChanged call to fix a...

### DIFF
--- a/currencyedittext/currencyedittext.iml
+++ b/currencyedittext/currencyedittext.iml
@@ -61,6 +61,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -80,7 +81,9 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/poms" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />

--- a/currencyedittext/src/main/java/com/blackcat/currencyedittext/CurrencyTextWatcher.java
+++ b/currencyedittext/src/main/java/com/blackcat/currencyedittext/CurrencyTextWatcher.java
@@ -64,6 +64,7 @@ class CurrencyTextWatcher implements TextWatcher {
 
         //Use the mIgnoreIteration flag to stop our edits to the text field from triggering an endlessly recursive call to afterTextChanged
         if(!mIgnoreIteration){
+            mIgnoreIteration = true;
             //Start by converting the editable to something easier to work with, then remove all non-digit characters
             String newText = editable.toString();
             newText = newText.replaceAll("[^0-9]", "");
@@ -85,7 +86,7 @@ class CurrencyTextWatcher implements TextWatcher {
                 newTextValue = newTextValue / CURRENCY_DECIMAL_DIVISOR;
                 String formattedAmount = mCurrencyFormatter.format(newTextValue);
 
-                mIgnoreIteration = true;
+                
                 mEditText.setText(formattedAmount);
 
                 //Track the last known good input so if there are any issues with new input, we can fall back gracefully.


### PR DESCRIPTION
... bug which caused a stack overflow when passing non-numeric values into setText().