### PR TITLE
v2.0.1 - fix for setText("") not resetting view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Generated files
 bin/
 gen/
+app/
 
 # Gradle files
 .gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha6'
     }
 
 }

--- a/currencyedittext/build.gradle
+++ b/currencyedittext/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 26
-        versionCode 200
+        versionCode 201
         versionName "2.0.0"
     }
 

--- a/currencyedittext/src/main/java/com/blackcat/currencyedittext/CurrencyTextWatcher.java
+++ b/currencyedittext/src/main/java/com/blackcat/currencyedittext/CurrencyTextWatcher.java
@@ -35,6 +35,14 @@ class CurrencyTextWatcher implements TextWatcher {
             String newText = editable.toString();
             String textToDisplay;
 
+
+            if (newText.length() < 1){
+                lastGoodInput = "";
+                editText.setRawValue(0);
+                editText.setText("");
+                return;
+            }
+
             newText = (editText.areNegativeValuesAllowed()) ? newText.replaceAll("[^0-9/-]", "") : newText.replaceAll("[^0-9]", "");
             if(!newText.equals("") && !newText.equals("-")){
                 //Store a copy of the raw input to be retrieved later by getRawValue

--- a/currencyedittexttester/build.gradle
+++ b/currencyedittexttester/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha6'
     }
 }
 

--- a/currencyedittexttester/src/main/java/com/blackcat/currencyedittexttester/MainActivity.java
+++ b/currencyedittexttester/src/main/java/com/blackcat/currencyedittexttester/MainActivity.java
@@ -9,7 +9,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.Button;
 import android.widget.NumberPicker;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -33,9 +32,6 @@ public class MainActivity extends Activity {
 
     @BindView(R.id.cet)
     CurrencyEditText cet;
-
-    @BindView(R.id.button)
-    Button refreshButton;
 
     @BindView(R.id.et_raw_val)
     TextView et_raw_val;
@@ -70,6 +66,12 @@ public class MainActivity extends Activity {
         configureDecimalDigitsTool();
     }
 
+    @OnClick(R.id.cet_reset_button)
+    void onResetClicked(){
+        cet.setText("");
+    }
+
+    @SuppressWarnings("unused")
     @SuppressLint("SetTextI18n")
     @OnClick(R.id.button)
     void onRefreshClicked(){

--- a/currencyedittexttester/src/main/res/layout/activity_main.xml
+++ b/currencyedittexttester/src/main/res/layout/activity_main.xml
@@ -35,6 +35,12 @@
                 android:id="@+id/cet"
                 />
 
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text = "@string/reset_button_text"
+                android:id="@+id/cet_reset_button"/>
+
         </LinearLayout>
 
         <TextView

--- a/currencyedittexttester/src/main/res/values/strings.xml
+++ b/currencyedittexttester/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="set_decimal_digits_tool">Set Decimal Digits Tool</string>
     <string name="setcurrency_currencyedittext_tool">SetCurrency CurrencyEditText Tool</string>
     <string name="currency_info">Currency Info:</string>
+    <string name="reset_button_text">Reset</string>
 </resources>

--- a/currencyedittexttester/src/test/java/com/blackcat/currencyedittexttester/CurrencyEditTextTests.java
+++ b/currencyedittexttester/src/test/java/com/blackcat/currencyedittexttester/CurrencyEditTextTests.java
@@ -170,9 +170,9 @@ public class CurrencyEditTextTests {
 
     @Test
     public void SetValueStoresProperValueTest(){
-        currencyEditText.setValue(100000);
+        currencyEditText.setValue(1000000);
         long result = currencyEditText.getRawValue();
-        assertThat(result, is(equalTo(100000L)));
+        assertThat(result, is(equalTo(1000000L)));
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=2.0.0-SNAPSHOT
-VERSION_CODE=200
+VERSION_NAME=2.0.1-SNAPSHOT
+VERSION_CODE=201
 GROUP=com.github.blackcat27
 
 POM_DESCRIPTION=A custom Android view for handling Currency input


### PR DESCRIPTION
This is a pretty important fix that should've gone into 2.0.0. My apologies for not getting it in there. You can now reset the view to show the hint again by calling  `setText("")`.